### PR TITLE
Add auth token to download requests

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -385,7 +385,8 @@ NPMLocation.prototype = {
     return new Promise(function(resolve, reject) {
       request({
         uri: versionData.dist.tarball,
-        headers: { 'accept': 'application/octet-stream' }
+        headers: { 'accept': 'application/octet-stream' },
+        auth: self.auth
       })
       .on('response', function(npmRes) {
 


### PR DESCRIPTION
This fixes the installing for us private npm users who have read ability only for authenticated users.

An alternative approach could be to read `always-auth` from `.npmrc` and decide the course, but sending the token always works as well.