### PR TITLE
add failing test for pinned version with equals and fix it

### DIFF
--- a/npm.js
+++ b/npm.js
@@ -772,7 +772,11 @@ function parseDependencies(dependencies, ui) {
           }
           else {
             // equality
-            lowerBound = upperBound = part.substr(1);
+            if (!part.match(semverRegEx)) {
+                lowerBound = upperBound = part.substr(1);
+            } else {
+                lowerBound = upperBound = part;
+            }
             lEq = uEq = true;
             break;
           }

--- a/test/unit.js
+++ b/test/unit.js
@@ -14,6 +14,8 @@ function testDependency(name, value, expectedName, expectedValue) {
   }
 }
 
+testDependency('react', '0.1.1', 'react', 'react@0.1.1');
+testDependency('react', '=0.1.1', 'react', 'react@0.1.1');
 testDependency('react', '<0.12', 'react', 'react@0.11.0');
 testDependency('react', '<0.12.0', 'react', 'react@0.11.0');
 testDependency('react', '~0.1.1', 'react', 'react@~0.1.1');
@@ -23,6 +25,8 @@ testDependency('react', '0.x', 'react', 'react@0');
 testDependency('react', '>=0.12.0', 'react', 'react@*');
 
 // Scoped
+testDependency('@scoped/react', '0.11.0', '@scoped/react', '@scoped/react@0.11.0');
+testDependency('@scoped/react', '=0.11.0', '@scoped/react', '@scoped/react@0.11.0');
 testDependency('@scoped/react', '<0.12', '@scoped/react', '@scoped/react@0.11.0');
 testDependency('@scoped/react', '<0.12.0', '@scoped/react', '@scoped/react@0.11.0');
 testDependency('@scoped/react', '~0.1.1', '@scoped/react', '@scoped/react@~0.1.1');


### PR DESCRIPTION
I'm trying to port a project running with require.js to jspm. I reached a problem where jspm could not install modules that have dependencies like the following:
```json
{
  "dependencies": {
    "foo": "=1.2.3"
  }
}
```

This fixes that. :-)