### PR TITLE
Fix password authentication

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -20,12 +20,10 @@ exports.decodeCredentials = decodeCredentials;
 function injectRequestOptions(requestOptions, auth) {
   if (!auth)
     return requestOptions;
-  if (auth.username)
-    requestOptions.auth = {
-      user: auth.username,
-      pass: auth.password
-    };
-  else if (auth.token) {
+  if (auth.username) {
+    requestOptions.headers = requestOptions.headers || {};
+    requestOptions.headers.authorization = 'Bearer ' + auth.username + ':' + auth.password;
+  }  else if (auth.token) {
     requestOptions.headers = requestOptions.headers || {};
     requestOptions.headers.authorization = 'Bearer ' + auth.token;
   }


### PR DESCRIPTION
There's an issue with npm authentication for jspm which prevents
user/pass authentication in 0.16.0-beta. Previously, lookup requests
were using basic authentication where only bearer authentication appears
to succeed. Alternatively, running npm login (and using authToken
instead) will also work for jspm 0.16.0-beta.

Fixes jspm/npm#78