### PR TITLE
Match the url NPM calculates to download a tarball

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -3,6 +3,7 @@ var asp = require('rsvp').denodeify;
 var request = require('request');
 var zlib = require('zlib');
 var tar = require('tar');
+var url = require('url');
 var fs = require('graceful-fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
@@ -322,9 +323,21 @@ NPMLocation.prototype = {
 
     var doAuth = this.alwaysAuth || repo[0] == '@';
 
+    // Forcing protocol and port matching for tarballs on the same host as the
+    // registry is taken from npm at
+    // https://github.com/npm/npm/blob/50ce116baac8b6877434ace471104ec8587bab90/lib/cache/add-named.js#L196-L208
+    var tarball = url.parse(versionData.dist.tarball);
+    var registry = url.parse(this.registryURL());
+
+    if (tarball.hostname === registry.hostname && tarball.protocol !== registry.protocol) {
+      tarball.protocol = registry.protocol;
+      tarball.port = registry.port;
+    }
+    tarball = url.format(tarball);
+
     return new Promise(function(resolve, reject) {
       request(auth.injectRequestOptions({
-        uri: versionData.dist.tarball,
+        uri: tarball,
         headers: { 'accept': 'application/octet-stream' },
         strictSSL: self.strictSSL
       }, doAuth && self.auth))


### PR DESCRIPTION
NPM modifies the tarball url if the protocol doesn't match the registry used to query for the tarball. This can be inspected in npm itself [here](https://github.com/npm/npm/blob/50ce116baac8b6877434ace471104ec8587bab90/lib/cache/add-named.js#L196-L208). This simply mirrors the behavior from NPM.

I discovered this because npm was working just fine, but jspm would fail to download npm resources because of a plain http proxy in the network that blocked access.