### PR TITLE
NPM conversion errors with name/repo#version type dependencies

### DIFF
--- a/lib/node-conversion.js
+++ b/lib/node-conversion.js
@@ -351,6 +351,8 @@ function parseDependencies(dependencies, ui) {
     else if (dep.split('/').length == 2) {
       name = 'github:' + dep.split('#')[0];
       version = dep.split('#')[1] || '*';
+      if (version.substr(0, 1) == 'v' && version.substr(1).match(semverRegEx))
+        version = version.substr(1);
     }
 
     // 5. version -> name@version


### PR DESCRIPTION
I was getting install errors like
```
err  Installing npm:@ortoo/angular-common@1.0.3, no version match for github:besite/jQuery.dotdotdot@v1.7.4
```

With a dependency of 
```javascript
{ "jQuery.dotdotdot": "besite/jQuery.dotdotdot#v1.7.4"}
```

This fixes it up