### PR TITLE
Ensure require id is a string

### DIFF
--- a/lib/node-conversion.js
+++ b/lib/node-conversion.js
@@ -250,6 +250,10 @@ exports.convertPackage = function(packageConfig, packageName, packageDir, ui) {
             map['./' + fileName.substr(0, fileName.length - 9) + '.js'] = './' + fileName;
 
           parsed.requires.forEach(function(req) {
+            // ensure req is a valid string
+            if (typeof req != 'string')
+              return;
+
             // package require by own name
             if (req.substr(0, packageName.length) == packageName && (req[packageName.length] == '/' || req.length == packageName.length)) {
               if (map)


### PR DESCRIPTION
Some modules, such as `npm:dagre`, contain [files][1] with non-string inputs to require, which currently aborts install with an error.

Ensuring each id is string first resolves this error originally reported as jspm/jspm-cli#1547.