### PR TITLE
(0.17) Strip ending / for directory requires (fixes jspm/registry#770)

### DIFF
--- a/lib/node-conversion.js
+++ b/lib/node-conversion.js
@@ -76,6 +76,9 @@ exports.convertPackage = function(packageConfig, packageName, packageDir, ui) {
     systemConfig.main = systemConfig.main || nodeResolve('index', '', fileTree);
     if (systemConfig.main.substr(0, 2) == './')
       systemConfig.main = systemConfig.main.substr(2);
+    // strip ending / for directory requires
+    if (systemConfig.main.length && systemConfig.main[systemConfig.main.length - 1] == '/')
+      systemConfig.main = systemConfig.main.substr(0, systemConfig.main.length - 1);
 
     var coreDeps = ['process'];
 


### PR DESCRIPTION
This fixes a total of **4** npm libraries: prelude-ls, type-check, LiveScript, and optionator.

I'm not sure whether this fix is suitable for such an extreme case, so maybe you'd prefer a change like this to be done per-library as an override in the registry?