### PR TITLE
Fix error reporting on failed lookup

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -212,7 +212,7 @@ NPMLocation.prototype = {
         return { versions: versions,
                  latest: latest };
       }, function(err) {
-        if (e.code == 'ENOTFOUND' && e.toString().indexOf('getaddrinfo') != -1 || e.code == 'ECONNRESET') {
+        if (err.code == 'ENOTFOUND' && err.toString().indexOf('getaddrinfo') != -1 || err.code == 'ECONNRESET') {
           err.retriable = true;
           err.hideStack = true;
         }


### PR DESCRIPTION
`e` → `err`

happened to set my HTTP_PROXY setting incorrectly and bumped into this ;)