### PR TITLE
Add gzip compression support for npm lookups

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -161,6 +161,7 @@ NPMLocation.prototype = {
       return asp(request)(auth.injectRequestOptions({
         uri: self.registryURL(scope) + '/' + repoPath,
         strictSSL: self.strictSSL,
+        gzip: true,
         headers: lookupCache ? {
           'if-none-match': lookupCache.eTag
         } : {}


### PR DESCRIPTION
Something must've updated today on either NPM or Heroku's NPM cache, because it was forcing the use of gzip even when the http `accept-encoding` header explicitly disallowed gzip. So.... an easy fix would be to add gzip support to npm lookups. This should have 0 downsides (uncompressed requests are still supported) with lots of upsides (less data transfer!).

without this patch it seems that all installs through heroku are failing for me using the standard `jspm install`