### PR TITLE
Add gzip compression support for npm lookups [0.16]

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -159,6 +159,7 @@ NPMLocation.prototype = {
       }
       return asp(request)(auth.injectRequestOptions({
         uri: self.registryURL(scope) + '/' + repoPath,
+        gzip: true,
         strictSSL: self.strictSSL,
         headers: lookupCache ? {
           'if-none-match': lookupCache.eTag


### PR DESCRIPTION
gotta get that pull request karma :smile: (it'd be very understandable if you'd prefer to do it manually too, but github only counts merged PRs on the master branch!) 
this is for master branch
see https://github.com/jspm/npm/pull/133 for comments