### PR TITLE
add support for distribution tags (aliases)

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -44,7 +44,7 @@ var NPMLocation = function(options, ui) {
   this.strictSSL = 'strictSSL' in options ? options.strictSSL : true;
 
   // cache versioning scheme used for patches
-  // this.versionString = options.versionString + '.1';
+  this.versionString = options.versionString + '.1';
 
   if (options.username && !options.auth)
     options.auth = auth.encodeCredentials(options.username, options.password);

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -183,16 +183,21 @@ NPMLocation.prototype = {
         var versions = {};
         var latest;
         var packageData;
+        var distTags;
 
         try {
           var json = JSON.parse(res.body);
-          var distTags = json['dist-tags'] || {};
+          distTags = json['dist-tags'] || {};
           packageData = json.versions;
           latest = distTags[latestKey];
         }
         catch(e) {
           throw 'Unable to parse package.json';
         }
+
+        for (var alias in distTags)
+          if (packageData[distTags[alias]])
+            packageData[alias] = packageData[distTags[alias]];
 
         for (var v in packageData) {
           if (packageData[v].dist && packageData[v].dist.shasum)


### PR DESCRIPTION
this fixes #61, by doing exactly what's in the OP:
>Basically we need to be reading all the tags in dist-tags and adding them to the versions lookup object.

So, I think this method works fine. It's similar to the jspm github approach, i.e. `github:user/repo@master` fetches the HEAD on master on every install.
npm uses a different approach - it saves the commit of master to package.json, and also for npm aliases, it will save the version the tag points to.

Though the npm way has nice pros (i.e. it creates no surprises), I think as long as the user knows that using an npm alias will result in possibly new versions on every install, everything is fine.