### PR TITLE
add support for maxRepoSize: fixes #116

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -42,6 +42,7 @@ var NPMLocation = function(options, ui) {
   this.tmpDir = options.tmpDir;
   this.remote = options.remote;
   this.strictSSL = 'strictSSL' in options ? options.strictSSL : true;
+  this.maxRepoSize = 'maxRepoSize' in options ? options.maxRepoSize * 1024 * 1024 : 50000000;
 
   // cache versioning scheme used for patches
   // this.versionString = options.versionString + '.1';
@@ -329,8 +330,8 @@ NPMLocation.prototype = {
         if (npmRes.statusCode != 200)
           return reject('Bad response code ' + npmRes.statusCode);
 
-        if (npmRes.headers['content-length'] > 50000000)
-          return reject('Response too large.');
+        if (self.maxRepoSize > 0 && npmRes.headers['content-length'] > self.maxRepoSize)
+          return reject('Response too large. Consider increasing the limit: jspm config registries.npm.maxRepoSize 100');
 
         npmRes.pause();
 


### PR DESCRIPTION
default is still 50Mb. If 0 or less, the size is ignored.

side-note: github maxRepoSize, like what I've done here, uses base2/non-SI units. these should probably be consolidated.