### PR TITLE
Only unzip if the npm package is gzipped

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -7,6 +7,7 @@ var url = require('url');
 var fs = require('graceful-fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
+var peek = require('buffer-peek-stream');
 var Npmrc = require('./npmrc');
 var auth = require('./auth');
 
@@ -14,6 +15,14 @@ var nodeConversion = require('./node-conversion');
 var Npmrc = require('./npmrc');
 
 var defaultRegistry = 'https://registry.npmjs.org';
+
+// Test whether the contents of buffer is gzipped
+function isGzip(buffer) {
+  if (!buffer || buffer.length < 3) {
+    return false;
+  }
+  return buffer[0] === 0x1f && buffer[1] === 0x8b && buffer[2] === 0x08;
+}
 
 function clone(a) {
   var b = {};
@@ -378,19 +387,28 @@ NPMLocation.prototype = {
 
         npmRes.pause();
 
-        var gzip = zlib.createGunzip();
+        // Peek at the first 16 bytes of npmRes to check if the contents are gzipped
+        peek(npmRes, 16, function(err, bytes, stream) {
+          if (err) return reject(err);
 
-        npmRes
-        .pipe(gzip)
-        .pipe(tar.Extract({
-          path: outDir,
-          strip: 1,
-          filter: function() {
-            return !this.type.match(/^.*Link$/);
+          // If the contents are gzipped pipe to gzip
+          if (isGzip(bytes)) {
+            var gzip = zlib.createGunzip();
+            stream = stream.pipe(gzip);
           }
-        }))
-        .on('error', reject)
-        .on('end', resolve);
+
+          // Unpack contents as a tar archive and save to outDir
+          stream
+            .pipe(tar.Extract({
+              path: outDir,
+              strip: 1,
+              filter: function() {
+                return !this.type.match(/^.*Link$/);
+              }
+            }))
+            .on('error', reject)
+            .on('end', resolve);
+        });
 
         npmRes.resume();
       })

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -6,7 +6,6 @@ var tar = require('tar');
 var url = require('url');
 var fs = require('graceful-fs');
 var path = require('path');
-var stream = require('stream');
 var mkdirp = require('mkdirp');
 var Npmrc = require('./npmrc');
 var auth = require('./auth');
@@ -15,42 +14,6 @@ var nodeConversion = require('./node-conversion');
 var Npmrc = require('./npmrc');
 
 var defaultRegistry = 'https://registry.npmjs.org';
-
-// Test whether the contents of buffer is gzipped
-function isGzip(buffer) {
-  if (!buffer || buffer.length < 3) {
-    return false;
-  }
-  return buffer[0] === 0x1f && buffer[1] === 0x8b && buffer[2] === 0x08;
-}
-
-// Return a promise that gunzips the buffer *if* it is gzipped
-// Otherwise return a promise with the buffer as is. 
-function gunzip(buffer) {
-  if (isGzip(buffer)) {
-    return new Promise(function (resolve, reject) {
-      zlib.gunzip(buffer, function (err, decoded) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(decoded);
-        }
-      });
-    });
-  } else {
-    return Promise.resolve(buffer);
-  }
-}
-
-// Create a readable stream from a buffer
-function bufferStream(buffer) {
-  return new stream.Readable({
-    read(size) {
-      this.push(buffer);
-      this.push(null);
-    }
-  });
-}
 
 function clone(a) {
   var b = {};
@@ -399,21 +362,6 @@ NPMLocation.prototype = {
     }
     tarball = url.format(tarball);
 
-    function extractTarBuffer(buffer) {
-      return new Promise(function (resolve, reject) {
-        bufferStream(buffer)
-          .pipe(tar.Extract({
-            path: outDir,
-            strip: 1,
-            filter: function() {
-              return !this.type.match(/^.*Link$/);
-            }
-          }))
-          .on('error', reject)
-          .on('end', resolve);
-      });
-    }
-
     return new Promise(function(resolve, reject) {
       request(auth.injectRequestOptions({
         uri: tarball,
@@ -428,23 +376,21 @@ NPMLocation.prototype = {
         if (npmRes.headers['content-length'] > 50000000)
           return reject('Response too large.');
 
-        var chunks = [];
-
         npmRes.pause();
 
-        npmRes.on('data', function (chunk) {
-          chunks.push(chunk);
-        });
+        var gzip = zlib.createGunzip();
 
-        npmRes.on('error', reject);
-
-        npmRes.on('end', function () {
-          Promise.resolve(Buffer.concat(chunks))
-            .then(gunzip)
-            .then(extractTarBuffer)
-            .then(resolve)
-            .catch(reject);
-        });
+        npmRes
+        .pipe(gzip)
+        .pipe(tar.Extract({
+          path: outDir,
+          strip: 1,
+          filter: function() {
+            return !this.type.match(/^.*Link$/);
+          }
+        }))
+        .on('error', reject)
+        .on('end', resolve);
 
         npmRes.resume();
       })

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -6,6 +6,7 @@ var tar = require('tar');
 var url = require('url');
 var fs = require('graceful-fs');
 var path = require('path');
+var stream = require('stream');
 var mkdirp = require('mkdirp');
 var Npmrc = require('./npmrc');
 var auth = require('./auth');
@@ -14,6 +15,42 @@ var nodeConversion = require('./node-conversion');
 var Npmrc = require('./npmrc');
 
 var defaultRegistry = 'https://registry.npmjs.org';
+
+// Test whether the contents of buffer is gzipped
+function isGzip(buffer) {
+  if (!buffer || buffer.length < 3) {
+    return false;
+  }
+  return buffer[0] === 0x1f && buffer[1] === 0x8b && buffer[2] === 0x08;
+}
+
+// Return a promise that gunzips the buffer *if* it is gzipped
+// Otherwise return a promise with the buffer as is. 
+function gunzip(buffer) {
+  if (isGzip(buffer)) {
+    return new Promise(function (resolve, reject) {
+      zlib.gunzip(buffer, function (err, decoded) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(decoded);
+        }
+      });
+    });
+  } else {
+    return Promise.resolve(buffer);
+  }
+}
+
+// Create a readable stream from a buffer
+function bufferStream(buffer) {
+  return new stream.Readable({
+    read(size) {
+      this.push(buffer);
+      this.push(null);
+    }
+  });
+}
 
 function clone(a) {
   var b = {};
@@ -362,6 +399,21 @@ NPMLocation.prototype = {
     }
     tarball = url.format(tarball);
 
+    function extractTarBuffer(buffer) {
+      return new Promise(function (resolve, reject) {
+        bufferStream(buffer)
+          .pipe(tar.Extract({
+            path: outDir,
+            strip: 1,
+            filter: function() {
+              return !this.type.match(/^.*Link$/);
+            }
+          }))
+          .on('error', reject)
+          .on('end', resolve);
+      });
+    }
+
     return new Promise(function(resolve, reject) {
       request(auth.injectRequestOptions({
         uri: tarball,
@@ -376,21 +428,23 @@ NPMLocation.prototype = {
         if (npmRes.headers['content-length'] > 50000000)
           return reject('Response too large.');
 
+        var chunks = [];
+
         npmRes.pause();
 
-        var gzip = zlib.createGunzip();
+        npmRes.on('data', function (chunk) {
+          chunks.push(chunk);
+        });
 
-        npmRes
-        .pipe(gzip)
-        .pipe(tar.Extract({
-          path: outDir,
-          strip: 1,
-          filter: function() {
-            return !this.type.match(/^.*Link$/);
-          }
-        }))
-        .on('error', reject)
-        .on('end', resolve);
+        npmRes.on('error', reject);
+
+        npmRes.on('end', function () {
+          Promise.resolve(Buffer.concat(chunks))
+            .then(gunzip)
+            .then(extractTarBuffer)
+            .then(resolve)
+            .catch(reject);
+        });
 
         npmRes.resume();
       })

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/jspm/npm/issues"
   },
   "dependencies": {
+    "buffer-peek-stream": "^1.0.1",
     "glob": "^5.0.10",
     "graceful-fs": "^4.1.3",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
It turns out that not all packages downloaded from npm are actually gzipped (even though they are named `*.tgz`). Specifically, I have seen this with the `@types` scope introduced recently for use with typescript. In theses cases jspm install fails when trying to unzip:

```sh
jspm install npm:@types/jquery
     Updating registry cache...
     Downloading npm:@types/jquery@1.10.28

err  Error: incorrect header check
    at Zlib._handle.onerror (zlib.js:370:17)
```

This pull request resolves this by checking whether the downloaded package is actually gzipped, and only extracts the tar contents if not.