### PR TITLE
Only unzip if the npm package is gzipped

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -7,6 +7,7 @@ var url = require('url');
 var fs = require('graceful-fs');
 var path = require('path');
 var mkdirp = require('mkdirp');
+var peek = require('buffer-peek-stream');
 var Npmrc = require('./npmrc');
 var auth = require('./auth');
 
@@ -15,6 +16,14 @@ var nodeConversion = require('./node-conversion');
 var Npmrc = require('./npmrc');
 
 var defaultRegistry = 'https://registry.npmjs.org';
+
+// Test whether the contents of buffer is gzipped
+function isGzip(buffer) {
+  if (!buffer || buffer.length < 3) {
+    return false;
+  }
+  return buffer[0] === 0x1f && buffer[1] === 0x8b && buffer[2] === 0x08;
+}
 
 function clone(a) {
   var b = {};
@@ -356,17 +365,26 @@ NPMLocation.prototype = {
 
         npmRes.pause();
 
-        var gzip = zlib.createGunzip();
+        // Peek at the first 16 bytes of npmRes to check if the contents are gzipped
+        peek(npmRes, 16, function(err, bytes, stream) {
+          if (err) return reject(err);
 
-        npmRes
-        .pipe(gzip)
-        .pipe(tar.extract(targetDir, {
-          strip: 1,
-          filter: function(_, header) {
-            return header.type !== 'file' && header.type !== 'directory'
+          // If the contents are gzipped pipe to gzip
+          if (isGzip(bytes)) {
+            var gzip = zlib.createGunzip();
+            stream = stream.pipe(gzip);
           }
-        }).on('finish', resolve).on('error', reject))
-        .on('error', reject);
+
+          // Unpack contents as a tar archive and save to targetDir
+          stream
+            .pipe(tar.extract(targetDir, {
+              strip: 1,
+              filter: function(_, header) {
+                return header.type !== 'file' && header.type !== 'directory'
+              }
+            }).on('finish', resolve).on('error', reject))
+            .on('error', reject);
+        });
 
         npmRes.resume();
       })

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "bluebird": "^3.0.5",
+    "buffer-peek-stream": "^1.0.1",
     "graceful-fs": "^4.1.3",
     "mkdirp": "^0.5.1",
     "readdirp": "^2.0.0",


### PR DESCRIPTION
It turns out that not all packages downloaded from npm are actually gzipped (even though they are named `*.tgz`). Specifically, I have seen this with the `@types` scope introduced recently for use with typescript. In theses cases jspm install fails when trying to unzip:

```sh
jspm install npm:@types/jquery
     Updating registry cache...
     Downloading npm:@types/jquery@1.10.28

err  Error: incorrect header check
    at Zlib._handle.onerror (zlib.js:370:17)
```

This pull request resolves this by checking whether the downloaded package is actually gzipped, and only extracts the tar contents if not.

This is basically the same PR as #147 but tweaked to work with 0.17