### PR TITLE
Export nodeBuiltins

### DIFF
--- a/lib/node-conversion.js
+++ b/lib/node-conversion.js
@@ -42,6 +42,8 @@ var nodeBuiltins = {
   'zlib': 'github:jspm/nodelibs-zlib@^0.1.0'
 };
 
+exports.nodeBuiltins = nodeBuiltins;
+
 var jsonPlugin = exports.jsonPlugin = 'github:systemjs/plugin-json@^0.1.0';
 
 exports.convertPackage = function(pjson, dir) {


### PR DESCRIPTION
Export nodeBuiltins, so that they can be used by other libs. Particularly, systemjs-config-builder.