### PR TITLE
Fix jspm-style warning output

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -290,7 +290,7 @@ NPMLocation.prototype = {
       if (!pjson.dependencies[d].match(/^(https?|git)[:+]/) && pjson.dependencies[d].indexOf(':') > 0)
         throw 'Package.json dependency %' + d + '% set to `' + pjson.dependencies[d] + '`, which is not a valid dependency format for npm.'
           + '\nIt\'s advisable to publish jspm-style packages to GitHub or another `registry` so conventions are clear.'
-          + '\nTo skip npm compatibility install with %jspm install ' + packageName + '-o "{jspmPackage: true}"%.';
+          + '\nTo skip npm compatibility install with %jspm install ' + packageName + ' -o "{jspmPackage: true}"%.';
 
 
     pjson.dependencies = nodeConversion.parseDependencies(pjson.dependencies, this.ui);


### PR DESCRIPTION
The `-o` switch in the message is attached to the package name due to a missing space, making the command fail if you just copy/paste it. This adds that missing space.