### PR TITLE
Fix unit test by mocha package upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "homepage": "https://github.com/jspm/npm",
   "devDependencies": {
     "istanbul": "0.3.21",
-    "mocha": "2.3.3",
-    "unexpected": "9.16.0",
-    "unexpected-mitm": "7.7.3"
+    "mocha": "^3.4.2",
+    "unexpected": "^10.29.0",
+    "unexpected-mitm": "^10.0.0"
   }
 }


### PR DESCRIPTION
The commit upgrades mocha and its testing dependencies to run with node >= 6.4.0.

As noted in [node-mitm@1.3.2](https://github.com/moll/node-mitm/commit446cb7e2a90816773026421b63de9d42d9535015), [node.js 6.4.0](https://github.com/nodejs/node/commit28071a130e2137bd14d0762a25f0ad83b7a28259) updates its buffer encoding. The testing dependencies unexpected-mitm needed an upgrade to fix type error running unit tests.