### PR TITLE
Honor npmrc cafile property on download

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -381,7 +381,10 @@ NPMLocation.prototype = {
       request(auth.injectRequestOptions({
         uri: tarball,
         headers: { 'accept': 'application/octet-stream' },
-        strictSSL: self.strictSSL
+        strictSSL: self.strictSSL,
+        agentOptions: registryInfo.ca ? {
+          ca: registryInfo.ca
+        } : {}
       }, registryInfo.auth))
       .on('response', function(npmRes) {
 


### PR DESCRIPTION
As #161 this PR fixes the download of packages of self signed registries. #161 fixed only the lookup of packages.