### PR TITLE
Refactor auth.injectRequestOptions() to handle auth and certificate options

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -21,9 +21,9 @@ function decodeCredentials(str) {
 exports.decodeCredentials = decodeCredentials;
 
 // given options for request, add the auth header / option as appropriate
-function injectRequestOptions(requestOptions, auth) {
-  if (!auth)
-    return requestOptions;
+function injectRequestOptions(requestOptions, registryInfo) {
+  registryInfo = registryInfo || {};
+  var auth = registryInfo.auth || {};
   if (auth.username)
     requestOptions.auth = {
       user: auth.username,
@@ -33,6 +33,10 @@ function injectRequestOptions(requestOptions, auth) {
     requestOptions.headers = requestOptions.headers || {};
     requestOptions.headers.authorization = 'Bearer ' + auth.token;
   }
+  if (registryInfo.ca)
+    requestOptions.agentOptions = {
+        ca: registryInfo.ca
+    };
   return requestOptions;
 }
 exports.injectRequestOptions = injectRequestOptions;
@@ -87,7 +91,7 @@ function configureCredentials(registry, _auth, ui) {
     .then(function() {
       return asp(request)(injectRequestOptions({
         uri: registry
-      }, _auth));
+      }, {auth: _auth}));
     })
     .then(function(res) {
       if (res.statusCode == 401)

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -192,11 +192,8 @@ NPMLocation.prototype = {
         strictSSL: self.strictSSL,
         headers: lookupCache ? {
           'if-none-match': lookupCache.eTag
-        } : {},
-        agentOptions: registryInfo.ca ? {
-          ca: registryInfo.ca
         } : {}
-      }, registryInfo.auth)).then(function(res) {
+      }, registryInfo)).then(function(res) {
         if (res.statusCode == 304)
           return { versions: lookupCache.versions,
                    latest: lookupCache.latest };
@@ -381,11 +378,8 @@ NPMLocation.prototype = {
       request(auth.injectRequestOptions({
         uri: tarball,
         headers: { 'accept': 'application/octet-stream' },
-        strictSSL: self.strictSSL,
-        agentOptions: registryInfo.ca ? {
-          ca: registryInfo.ca
-        } : {}
-      }, registryInfo.auth))
+        strictSSL: self.strictSSL
+      }, registryInfo))
       .on('response', function(npmRes) {
 
         if (npmRes.statusCode != 200)

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -98,8 +98,10 @@ describe('lib/auth', function () {
         });
         it('should inject BasicAuth options into request options', function () {
             requestOptions = auth.injectRequestOptions(requestOptions, {
-                username: 'foo',
-                password: 'bar'
+                auth: {
+                    username: 'foo',
+                    password: 'bar'
+                }
             })
             return expect(requestOptions, 'to satisfy', {
                 auth: {
@@ -110,7 +112,9 @@ describe('lib/auth', function () {
         });
         it('should inject auth tokens into request options', function () {
             requestOptions = auth.injectRequestOptions(requestOptions, {
-                token: 'foobar'
+                auth: {
+                    token: 'foobar'
+                }
             })
             return expect(requestOptions, 'to satisfy', {
                 headers: {
@@ -123,12 +127,24 @@ describe('lib/auth', function () {
                 'X-Custom-Header': 'helloworld'
             };
             requestOptions = auth.injectRequestOptions(requestOptions, {
-                token: 'foobar'
+                auth: {
+                    token: 'foobar'
+                }
             })
             return expect(requestOptions, 'to satisfy', {
                 headers: {
                     'X-Custom-Header': 'helloworld',
                     authorization: 'Bearer foobar'
+                }
+            });
+        });
+        it('should inject certificate options into request options', function () {
+            requestOptions = auth.injectRequestOptions(requestOptions, {
+                ca: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'
+            })
+            return expect(requestOptions, 'to satisfy', {
+                agentOptions: {
+                    ca: '-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----'
                 }
             });
         });


### PR DESCRIPTION
The request option handling of auth and certifications settings are unified in the auth object to avoid further changes and failures like #161 and #163.